### PR TITLE
Issues/#7

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,7 +14,7 @@ class TasksController < ApplicationController
   end
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def show

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,15 +1,17 @@
 <h1>タスク一覧</h1>
 <p><%= notice %></p>
 <table>
-  <tr>
+  <tr class >
     <th>タスク名</th>
     <th>内容</th>
+    <th>投稿日時</th>
   </tr>
 
 <% @tasks.each do |task| %>
-  <tr>
+  <tr class = "task_list" >
     <td><%= task.task_name %></td>
     <td><%= task.content %></td>
+    <td><%= task.created_at.strftime('%Y年%m月%d日') %></td>
     <td><%= link_to '詳細',task_path(task.id) %></td>
     <td><%= link_to '編集',edit_task_path(task.id) %></td> 
     <td><%= link_to '削除',task_path(task.id), method: :delete %></td> 

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+
+    factory :task do
+      task_name { '課題1' }
+      content { 'テスト1' }
+      created_at{Time.zone.now}
+    end
+
+    factory :second_task, class: Task do
+      task_name { '課題2' }
+      content { 'テスト2' }
+      created_at{Time.zone.now+ 1.days}
+    end
+  end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -4,17 +4,18 @@ require 'rails_helper'
 # このRSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
 RSpec.feature "タスク管理機能", type: :feature do
     background do
-        Task.create!(task_name: '課題１', content: 'テスト')
+        FactoryBot.create(:task)
+        FactoryBot.create(:second_task)
       end
 
   scenario "タスク一覧のテスト" do
 
     visit tasks_path
 
-    save_and_open_page
-
-    expect(page).to have_content '課題１'
-    expect(page).to have_content 'テスト'
+    expect(page).to have_content '課題1'
+    expect(page).to have_content 'テスト1'
+    expect(page).to have_content '課題2'
+    expect(page).to have_content 'テスト2'
 
   end
 
@@ -23,20 +24,30 @@ RSpec.feature "タスク管理機能", type: :feature do
     visit new_task_path
 
     fill_in 'task_task_name', with: '課題１'
-    fill_in 'task_content', with: 'テスト'
+    fill_in 'task_content', with: 'テスト1'
 
-    click_on 'Create Task'
+    click_on '登録する'
 
     expect(page).to have_content '課題１'
-    expect(page).to have_content 'テスト'
+    expect(page).to have_content 'テスト1'
   end
 
   scenario "タスク詳細のテスト" do
 
     visit task_path(Task.last)
 
-    expect(page).to have_content '課題１'
-    expect(page).to have_content 'テスト'
+    expect(page).to have_content '課題2'
+    expect(page).to have_content 'テスト2'
+
+  end
+
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+
+    visit tasks_path
+    task = all('.task_list')
+    task_0 = task[0]
+    expect(task_0).to have_content "テスト2"
+    save_and_open_page
 
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,8 @@ RSpec.configure do |config|
 
   config.filter_rails_from_backtrace!
 
+  config.include FactoryBot::Syntax::Methods
+
   config.before(:suite) do
     DatabaseCleaner.strategy = :truncation
   end


### PR DESCRIPTION
<Prefix>: add：indexアクションに作成日時の降順で表示する機能実装

<Body>

<Prefix>:add : タスクが作成日時の降順に並んでいるかのテスト実装

<Body>

 add: tr class = "task_list" 要素を取得するため

 add: FactoryBot


