### PR TITLE
[fixed]バリデーション設定,エラーメッセージ表示,モデルテスト実装

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,4 @@
 class Task < ApplicationRecord
-    validates :task_name, presence: true
-    validates :content, presence: true, length:{ maximum:100}
+  validates :task_name, presence: true
+  validates :content, presence: true, length:{ maximum:100}
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,4 +1,15 @@
 <%= form_with(model:@task,local: true)  do |f| %>
+  <% if @task.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= @task.errors.count %>件のエラーがあります。</h2>
+    <ul>
+
+    <% @task.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
     <div class="task_name">
       <%= f.label :タスク名 %>
       <%= f.text_field :task_name %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,10 @@ ja:
   activerecord:
     models:
       task: タスク
+    attributes:
+      task:
+        task_name: タスク名
+        content: 内容
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'
@@ -134,6 +138,8 @@ ja:
       too_long: は%{count}文字以内で入力してください
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
+      task_name: タスク名
+      content: 内容
     template:
       body: 次の項目を確認してください
       header:

--- a/db/migrate/20190817120723_change_column_null_tasks.rb
+++ b/db/migrate/20190817120723_change_column_null_tasks.rb
@@ -1,0 +1,6 @@
+class ChangeColumnNullTasks < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :tasks, :task_name, false
+    change_column_null :tasks, :content, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_15_082232) do
+ActiveRecord::Schema.define(version: 2019_08_17_120723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "task_name"
-    t.text "content"
+    t.string "task_name", null: false
+    t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,18 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-    # 名前があれば有効な状態にすること
-    it "is valid with a task_name, content" do
-        task = Task.new(
-            task_name:'課題１',
-            content:'テスト')
-        expect(task).to be_valid
-    end
-    # コンテントが101文字以上なら無効な状態であること
-    it "is invalid with content is 101 or more characters" do
-        task = Task.new(content:'1'*102)
-        task.valid?
-        expect(task.errors[:content]).to include("is too long (maximum is 100 characters)")
+
+    it "titleが空ならバリデーションが通らない" do
+      task = Task.new(task_name:'',content:'失敗テスト')
+      expect(task).not_to be_valid
     end
 
+    it "contentが空ならバリデーションが通らない" do
+      task = Task.new(task_name:'失敗テスト',content:'')
+      expect(task).not_to be_valid
+    end
+
+    it "titleとcontentに内容が記載されていればバリデーションが通る" do
+      task = Task.new(task_name:'テスト１',content:'テスト１')
+      expect(task).to be_valid
+    end
   end


### PR DESCRIPTION
Issues/#9

追加:カラムにNot NULL制約を実装

追加: エラーメッセージの表示

追加： エラーメッセージの日本語化

追加:モデルのテスト追加
