### PR TITLE
ステップ19: 複数人で利用できるようにしよう（ユーザ概念の導入)&ステップ20: ログイン/ログアウト機能を実装しよう 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'rails-i18n', '~> 5.1'
-gem 'kaminari'
+gem 'bcrypt', '3.1.11'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -23,6 +23,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'faker'
 end
 
 group :development do
@@ -39,9 +40,10 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   gem 'chromedriver-helper'
-  gem 'faker'
   gem 'database_cleaner'
   gem 'rspec-rails'
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'kaminari'
+gem 'toastr_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    bcrypt (3.1.11)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -231,6 +232,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    toastr_rails (2.1.3)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -253,6 +255,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (= 3.1.11)
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)
@@ -279,6 +282,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
+  toastr_rails
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ heroku run rails db:migrate
 
 | model | 外部キー |カラム|カラム|カラム|カラム|カラム|
 ----|----|----|----|----|----|----
-| user | ---- | name | ---- | ---- | ---- | ---- |
+| user | ---- | name | email  | password_digest  | ---- | ---- |
 | task | user_id | task_name | content | limit | status | priority |
 | label| task_id | label_name | ---- | ---- | ---- | ---- |
 
@@ -37,6 +37,8 @@ User
 | カラム | 型 |
 ----|----
 | name | string |
+| email | string |
+| password_digest | string |
 
 Task
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,5 @@
 //= require activestorage
 //= require turbolinks
 //= require jquery/dist/jquery.js
+//= require toastr
 //= require_tree .

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -9,7 +9,7 @@
  * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
- *
+ *= require toastr_rails
  *= require bootstrap/dist/css/bootstrap.min
  *= require_tree .
  *= require_self

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,16 @@ class ApplicationController < ActionController::Base
     #     name == ENV['BASIC_AUTH_NAME'] && password == ENV['BASIC_AUTH_PASSWORD']
     #   end
     # end
+
+  protect_from_forgery with: :exception
+  include SessionsHelper
+
+  before_action :login_required
+
+  private
+
+  def login_required
+    redirect_to new_session_path unless current_user
+  end
+
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,30 @@
+class SessionsController < ApplicationController
+  skip_before_action :login_required
+  def new
+  end
+
+  def create
+    user = User.find_by(email: session_params[:email].downcase)
+    if user && user.authenticate(session_params[:password])
+      session[:user_id] = user.id
+      flash[:success] = 'ログインに成功しました'
+      redirect_to user_path(user.id)
+    else
+      flash.now[:danger] = 'ログインに失敗しました'
+      render'new'
+    end
+  end
+
+  def destroy
+    reset_session
+    flash[:info] = 'ログアウトしました'
+    redirect_to new_session_path
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email,:password)
+  end
+
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,16 +5,17 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
+    @task = current_user.tasks.build(task_params)
     if @task.save
-    redirect_to task_path(@task.id),notice: "タスクを作成しました"
+    flash[:info] = 'タスクを作成しました'
+    redirect_to task_path(@task.id)
     else
       render 'new'
     end
   end
 
   def index
-    @task = Task.all
+    @task = current_user.tasks
     if params[:search].nil?
       if params[:sort_expired]
         @tasks = @task.expired_sort
@@ -26,9 +27,9 @@ class TasksController < ApplicationController
     else
       if  params[:task] && params.dig(:task, :title).present? && params.dig(:task, :status).present?
         @tasks = Task.search_title(params).search_status(params)
-      elsif params[:task] &&  params.dig(:task, :title).present? && params.dig(:task, :status).blank?
+      elsif params[:task] && params.dig(:task, :title).present? && params.dig(:task, :status).blank?
         @tasks = Task.search_title(params)
-      elsif params[:task] &&  params.dig(:task, :title).blank? && params.dig(:task, :status).present?
+      elsif params[:task] && params.dig(:task, :title).blank? && params.dig(:task, :status).present?
         @tasks = Task.search_status(params)
       else
         @tasks = @task.recent
@@ -45,7 +46,8 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      redirect_to tasks_path, notice: "タスクを編集しました"
+      flash[:success] = 'タスクを更新しました'
+      redirect_to tasks_path
     else
       render :edit
     end
@@ -53,7 +55,8 @@ class TasksController < ApplicationController
 
   def destroy
     @task.destroy
-    redirect_to tasks_path, notice: "タスクを削除しました"
+    flash[:info] = 'タスクを削除しました'
+    redirect_to tasks_path
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,45 @@
+class UsersController < ApplicationController
+  before_action :set_user,only: [:show]
+  before_action :user_identify, only:[:show]
+  skip_before_action :login_required
+  def new
+    if logged_in?
+      redirect_to root_path
+    else
+      @user = User.new
+    end
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      session[:user_id] = @user.id
+      flash[:success] = 'ユーザ作成に成功しました'
+      redirect_to user_path(@user.id)
+    else
+      flash.now[:danger] = '作成に失敗しました'
+      render 'new'
+    end
+  end
+
+  def show
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name,:email,:password,:password_confirmation)
+  end
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_identify
+    @user = User.find(params[:id])
+    unless @user == current_user
+      redirect_to root_path
+    end
+  end
+
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,8 @@
+module SessionsHelper
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
+  def logged_in?
+    current_user.present?
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 class Task < ApplicationRecord
+  belongs_to :user
   validates :title,   presence: true
   validates :content, presence: true, length:{ maximum:100}
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,9 @@
+class User < ApplicationRecord
+  has_many :tasks,dependent: :destroy
+  has_secure_password
+  validates :password_digest, presence: true, length: { minimum: 6 }
+  validates :name, presence: true,length: { maximum: 20 }
+  validates :email, presence: true,length:{ maximum: 40 },
+                      format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  before_validation { email.downcase! }
+end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,0 +1,27 @@
+<nav class="navbar navbar-default">
+	<div class="container-fluid">
+		<div class="navbar-header">
+			<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbarEexample1">
+				<span class="sr-only"></span>
+				<span class="icon-bar"></span>
+				<span class="icon-bar"></span>
+				<span class="icon-bar"></span>
+			</button>
+		</div>
+
+		<div class="collapse navbar-collapse" id="navbarEexample1">
+			<ul class="nav navbar-nav">
+				<% if logged_in? %>
+					<li><%= link_to 'ログアウト',session_path(current_user.id),method: :delete,class:'btn btn-default btn-block' %></li>
+					<li><%= link_to 'マイページ',user_path(current_user.id),class:'btn btn-default btn-block' %></li>
+					<li><%= link_to 'ユーザー一覧',users_path,class:'btn btn-default btn-block'  %></li>
+					<li><%= link_to 'タスク一覧',tasks_path,class:'btn btn-default btn-block'  %></li>
+					<li><%= link_to '新規作成',new_task_path,class:'btn btn-default btn-block'  %></li>
+				<% else %>
+					<li><%= link_to 'サインアップ',new_user_path,class:'btn btn-default btn-block'%></li>
+					<li><%= link_to 'ログイン',new_session_path,class:'btn btn-default btn-block' %></li>
+				<% end %>
+			</ul>
+		</div>
+	</div>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,22 @@
   </head>
 
   <body>
-  
+    <%= render 'layouts/navbar' %>
+    <% if flash.any? %>
+      <script type="text/javascript">
+        toastr.options = {
+          "positionClass": "toast-top-center",
+          "timeOut": "3000",
+          "progressBar": true
+        }
+        <% flash.each do |key, value| %>
+          <% key = "info" if key == "info" %>
+          <% key = "success" if key == "notice" %>
+          <% key = "warning" if key == "danger" %>
+          toastr['<%= key %>']('<%= value %>');
+        <% end %>
+      </script>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,27 @@
+<div class="container">
+  <div class = "row">
+    <div class="main col-md-12">
+      <br>
+      <br>
+      <h1>ログイン</h1>
+      <br>
+      <%= form_with(scope: :session, url: sessions_path, local: true) do |f| %>
+        <%= f.label :email %>
+        <br>
+        <br>
+        <%= f.email_field :email %>
+        <br>
+        <br>
+        <%= f.label :パスワード %>
+        <br>
+        <br>
+        <%= f.password_field :password %>
+        <br>
+        <br>
+        <br>
+        <%= f.submit "ログインする" %>
+        <br>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,43 +1,42 @@
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-<br>
-
 <div class="container">
   <div class = "row">
-    <div class="col-md-2">
+    <div class="main col-md-12">
+      <%= form_with(model:@task,local: true)  do |f| %>
+        <% if @task.errors.any? %>
+          <div id="error_explanation">
+            <h2><%= @task.errors.count %>件のエラーがあります。</h2>
+              <ul>
+                <% @task.errors.full_messages.each do |msg| %>
+                  <li><%= msg %></li>
+                <% end %>
+              </ul>
+          </div>
+        <% end %>
+        <%= f.label :タイトル %>
+        <%= f.text_field :title %>
+        <br>
+        <br>
+        <br>
+        <%= f.label :内容%>
+        <%= f.text_field :content %>
+        <br>
+        <br>
+        <br>
+        <%= f.label :状態%>
+        <%= f.select :status, ['未着手','着手中','完了'], include_blank: true, selected: '' %>
+        <br>
+        <br>
+        <br>
+        <%= f.label :優先順位 %>
+        <%= f.select :priority, ['高','中','低'], include_blank: true, selected: '' %>
+        <br>
+        <br>
+        <br>
+        <%= f.submit  %>
+        <br>
+        <br>
+        <br>
+        <% end %>
     </div>
-    <div class="main col-md-8">
-    <%= form_with(model:@task,local: true)  do |f| %>
-    <% if @task.errors.any? %>
-    <div id="error_explanation">
-    <h2><%= @task.errors.count %>件のエラーがあります。</h2>
-    <ul>
-    <% @task.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
-    <% end %>
-    </ul>
-    </div>
-    <% end %>
-    <%= f.label :タイトル %>
-    <%= f.text_field :title %>
-    <br>
-    <%= f.label :内容%>
-    <%= f.text_field :content %>
-    <br>
-    <%= f.label :状態%>
-    <%= f.select :status, ['未着手','着手中','完了'], include_blank: true, selected: '' %>
-    <br>
-    <%= f.label :優先順位 %>
-    <%= f.select :priority, ['高','中','低'], include_blank: true, selected: '' %>
-    <br>
-    <%= f.submit  %>
-    <% end %>
-    <%= link_to '戻る',tasks_path %>
-    </div>
-    <div class="col-md-2">
-    </div>
+  </div>
+</div>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,4 +1,11 @@
+<br>
+<br>
+<br>
+<br>
 <div class = "form_title">
 <h1><strong>タスク編集</strong></h1>
 </div>
+<br>
+<br>
+<br>
 <%= render 'form' %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,67 +1,51 @@
 <div class="container">
-  <header class="header"><strong>タスク一覧</strong></header>
-    <div class = "row">
-      <div class="main_left col-md-6">
-      <br>
-      <br>
-      <br>
-      <br>
-      <br>
-      <br>
-      <br>
-      <br>
-        <p><%= notice %></p>
-          <%= link_to '新規作成',new_task_path %>
-        <br>
-          <%= link_to "終了期限でソートする", tasks_path(sort_expired: "true") %>
-        <br>
-        <%= link_to "優先順位で高い順にソートする", tasks_path(sort_priority: "true") %>
-
-        <%= form_with( model:Task.new, url: tasks_path, method: :get, local: true) do |f| %>
-          <%= f.label :title, "タイトル検索"  %>
-          <%= f.text_field :title %>
-          <br>
-          <%= f.label :status, "状態検索" %>
-          <%= f.select :status, ['未着手','着手中','完了'], include_blank: true, selected: '' %>
-
-          <%= f.hidden_field :search, value: 'true' %>
-          <br>
-          <%= f.submit '絞り込み検索'%>
-
-          <% end %>
-      </div>
+  <div class = "row">
+    <div class="main col-md-12">
+      <p><%= notice %></p>
+      <h1>タスク一覧</h1>
+      <%= link_to "終了期限でソートする", tasks_path(sort_expired: "true") %>
+      <%= link_to "優先順位で高い順にソートする", tasks_path(sort_priority: "true") %>
+      <%= form_with( model:Task.new, url: tasks_path, method: :get, local: true) do |f| %>
+        <%= f.label :title, "タイトル検索"  %>
+        <%= f.text_field :title %>
+        <%= f.label :status, "状態検索" %>
+        <%= f.select :status, ['未着手','着手中','完了'], include_blank: true, selected: '' %>
+        <%= f.hidden_field :search, value: 'true' %>
+        <%= f.submit '絞り込み検索'%>
+      <% end %>
+    </div>
 
 <%= paginate @tasks %>
 
-      <div class="main_right col-md-6">
-        <table class="table table-condensed">
-          <tr class = "info">
-            <th>タイトル</th>
-            <th>内容</th>
-            <th>投稿日時</th>
-            <th>詳細</th>
-            <th>編集</th>
-            <th>削除</th>
-            <th>終了期限</th>
-            <th>状態</th>
-            <th>優先順位</th>
+    <div class="main_right col-md-12">
+      <table class="table table-condensed">
+        <tr class = "info">
+          <th>タイトル</th>
+          <th>内容</th>
+          <th>投稿日時</th>
+          <th>詳細</th>
+          <th>編集</th>
+          <th>削除</th>
+          <th>終了期限</th>
+          <th>状態</th>
+          <th>優先順位</th>
+        </tr>
+        <% @tasks.each do |task| %>
+          <tr class = "task_list" >
+            <td><%= task.title %></td>
+            <td><%= task.content %></td>
+            <td><%= task.created_at.strftime('%Y/%m/%d %H:%M') %></td>
+            <td><%= link_to '詳細',task_path(task.id) %></td>
+            <td><%= link_to '編集',edit_task_path(task.id) %></td>
+            <td><%= link_to '削除',task_path(task.id), method: :delete %></td>
+            <td><%= task.expired.strftime('%Y年%-m月%-d日 %H:%M' ) %></td>
+            <td><%= task.status %></td>
+            <td><%= task.priority %></td>
           </tr>
-          <% @tasks.each do |task| %>
-            <tr class = "task_list" >
-              <td><%= task.title %></td>
-              <td><%= task.content %></td>
-              <td><%= task.created_at.strftime('%Y/%m/%d %H:%M') %></td>
-              <td><%= link_to '詳細',task_path(task.id) %></td>
-              <td><%= link_to '編集',edit_task_path(task.id) %></td>
-              <td><%= link_to '削除',task_path(task.id), method: :delete %></td>
-              <td><%= task.expired.strftime('%Y年%-m月%-d日 %H:%M' ) %></td>
-              <td><%= task.status %></td>
-              <td><%= task.priority %></td>
-            </tr>
-          <% end %>
-        </>
-      </div>
+        <% end %>
+      </table>
     </div>
   </div>
+</div>
 
 

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,4 +1,11 @@
+<br>
+<br>
+<br>
+<br>
 <div class = "form_title">
 <h1><strong>新規タスク作成</strong></h1>
 </div>
+<br>
+<br>
+<br>
 <%= render 'form' %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,12 +1,16 @@
 <div class = "form_title">
+<br>
+<br>
+<br>
 <h1><strong>タスク詳細</strong></h1>
 </div>
 <br>
 <br>
-<p><%= notice %></p>
+<br>
 <div class="container">
   <div class = "row">
     <div class="col-md-2">
+    <p><%= notice %></p>
     </div>
     <div class = "main col-md-8">
       <br>
@@ -19,8 +23,11 @@
       <p>優先順位: <%= @task.priority %></p>
       <br>
       <%= link_to 'タスク一覧',tasks_path %>
-    <br>
-    <br>
+      <br>
+      <br>
     </div>
     <div class ="col-md-2">
     </div>
+  </div>
+</div>
+  

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,39 @@
+<div class="container">
+  <div class = "row">
+    <div class="main col-md-12">
+      <br>
+      <br>
+      <h1>サインアップ</h1>
+      <br>
+        <%= form_with(model: @user, local: true) do |f| %>
+          <%= f.label :名前 %>
+          <br>
+          <br>
+          <%= f.text_field :name %>
+          <br>
+          <br>
+          <%= f.label :email %>
+          <br>
+          <br>
+          <%= f.email_field :email %>
+          <br>
+          <br>
+          <%= f.label :パスワード %>
+          <br>
+          <br>
+          <%= f.password_field :password %>
+          <br>
+          <br>
+          <%= f.label :パスワード確認 %>
+          <br>
+          <br>
+          <%= f.password_field :password_confirmation %>
+          <br>
+          <br>
+          <br>
+          <br>
+          <%= f.submit "アカウントを作成する" %>
+        <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,33 @@
+<br>
+<br>
+<br>
+<br>
+<br>
+<div class = "form_title">
+<h1><strong>ユーザー詳細</strong></h1>
+</div>
+<br>
+<br>
+<br>
+<p><%= notice %></p>
+<div class="container">
+  <div class = "row">
+    <div class="col-md-2">
+    </div>
+    <div class = "main col-md-8">
+      <br>
+      <br>
+      <p>ユーザ名: <%= @user.name %></p>
+      <br>
+      <br>
+      <br>
+      <p>email: <%= @user.email %></p>
+      <br>
+      <br>
+      <br>
+      <%= link_to 'タスク一覧',tasks_path %>
+    </div>
+    <div class ="col-md-2">
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
   root 'tasks#index'
   resources:tasks
+  resources:users
+  resources:sessions, only: [:new, :create, :destroy]
 end
+
+

--- a/db/migrate/20190903083150_create_users.rb
+++ b/db/migrate/20190903083150_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :name, null:false
+      t.string :email, null:false
+      t.string :password_digest, null:false
+
+      t.timestamps
+      t.index :email, unique: true
+    end
+  end
+end

--- a/db/migrate/20190903090009_add_user_ref_to_tasks.rb
+++ b/db/migrate/20190903090009_add_user_ref_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddUserRefToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tasks, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2019_09_03_090009) do
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "expired", default: "2019-08-19 20:02:55"
+    t.datetime "expired", default: "2019-09-04 17:03:15"
     t.string "status", default: "未着手"
     t.integer "priority"
     t.bigint "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_30_061022) do
+ActiveRecord::Schema.define(version: 2019_09_03_090009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +23,20 @@ ActiveRecord::Schema.define(version: 2019_08_30_061022) do
     t.datetime "expired", default: "2019-08-19 20:02:55"
     t.string "status", default: "未着手"
     t.integer "priority"
+    t.bigint "user_id"
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title"], name: "index_tasks_on_title"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "tasks", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,14 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+5.times do |n|
+    name = Faker::Games::Pokemon.name
+    email = Faker::Internet.email
+    password = "password"
+    User.create!(name: name,
+                 email: email,
+                 password: password,
+                 password_confirmation: password,
+                 )
+  end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -7,15 +7,17 @@ FactoryBot.define do
       expired{Time.zone.now}
       status { '完了' }
       priority {'高'}
+      user_id { User.last.id }
     end
 
-    factory :second_task, class: Task do
+    factory :second_task , class: Task do
       title { '課題2' }
       content { 'テスト2' }
       created_at{Time.zone.now+ 1.days}
       expired{Time.zone.now + 1.days}
       status { '着手中'}
       priority {'中'}
+      user_id { User.last.id }
     end
 
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { "MyString" }
+    email { "MyString" }
+    password_digest { "MyString" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,17 @@
 FactoryBot.define do
+
   factory :user do
-    name { "MyString" }
-    email { "MyString" }
-    password_digest { "MyString" }
+    name { '111' }
+    email { '1@1.com' }
+    password { '111111' }
+    password_confirmation {'111111'}
   end
+
+  factory :second_user do
+    name { '222' }
+    email { '2@2.com' }
+    password { '222222' }
+    password_confirmation { '222222' }
+  end
+
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -1,12 +1,21 @@
-# このrequireで、Capybaraなどの、Feature Specに必要な機能を使用可能な状態にしています
+
 require 'rails_helper'
 
-# このRSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
 RSpec.feature "タスク管理機能", type: :feature do
   background do
 
+    FactoryBot.create(:user)
     FactoryBot.create(:task)
     FactoryBot.create(:second_task)
+
+  end
+
+  before do
+
+    visit new_session_path
+    fill_in 'session_email', with: '1@1.com'
+    fill_in 'session_password', with: '111111'
+    click_on 'ログインする'
 
   end
 
@@ -128,7 +137,7 @@ RSpec.feature "タスク管理機能", type: :feature do
 
   end
 
-  #bin/rspec spec/features/task.spec.rb
-  #save_and_open_page
-
 end
+
+#bin/rspec spec/features/task.spec.rb
+  #save_and_open_page

--- a/spec/features/user.spec.rb
+++ b/spec/features/user.spec.rb
@@ -1,0 +1,69 @@
+
+require 'rails_helper'
+
+RSpec.feature "ユーザ登録機能", type: :feature do
+    background do
+
+      FactoryBot.create(:user)
+
+    end
+
+    scenario "ユーザ登録のテスト" do
+
+      visit new_user_path
+
+      fill_in 'user_name', with: '333'
+      fill_in 'user_email', with: '3@3.com'
+      fill_in 'user_password', with: '333333'
+      fill_in 'user_password_confirmation', with: '333333'
+
+      click_on 'アカウントを作成する'
+
+      expect(page).to have_text '333'
+      expect(page).to have_text '3@3.com'
+
+    end
+
+    scenario "ログイン状態ではないとタスク一覧ページに遷移ができないテスト" do
+
+        visit tasks_path
+
+        expect(page).to have_text'ログイン'
+
+    end
+
+    scenario "ログイン状態でユーザー登録画面に行かせないテスト" do
+
+        visit new_session_path
+
+        fill_in 'session_email', with: '1@1.com'
+        fill_in 'session_password', with: '111111'
+
+        click_on 'ログインする'
+
+        visit new_user_path
+
+        expect(page).to have_text'タスク一覧'
+
+    end
+
+    scenario "ログイン状態で他のユーザーの詳細ページに行かせないテスト" do
+
+        visit new_user_path
+
+        fill_in 'user_name', with: '333'
+        fill_in 'user_email', with: '3@3.com'
+        fill_in 'user_password', with: '333333'
+        fill_in 'user_password_confirmation', with: '333333'
+
+        click_on 'アカウントを作成する'
+
+        visit user_path(User.first)
+
+        expect(page).to have_text'タスク一覧'
+    end
+
+end
+
+ #bin/rspec spec/features/user.spec.rb
+#save_and_open_page

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
issues/#21

[ステップ１９]
ユーザモデルを作成
最初のユーザをseedで作成
ユーザとタスクが紐づける
ユーザのアドレスにユニーク制約を貼る
関連（アソシエーションで使用するid）に対してインデックスを貼る

[ステップ２０]
ログイン画面を実装
ログアウト機能を実装
ログインしていないのにタスクのページに飛ぼうとした場合は、ログインページに遷移させる
自分が作成したタスクだけを表示させる
ユーザーの登録（new）画面と、詳細・マイページ（show）画面を作成
ユーザ登録（create）をした時、同時にログインもさせる
ログインしている時は、ユーザー登録画面（new画面）に行かせない
自分（current_user）以外のユーザのマイページ（userのshow画面）に行かせない
これらの内容を加味して、userテストを作成
