### PR TITLE
Issues/#25

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < ApplicationController
   before_action :set_user,only: [:show,:edit,:update,:destroy]
+  before_action :require_admin,only: [:index,:new,]
   def new
     @user = User.new
   end
@@ -20,6 +21,7 @@ class Admin::UsersController < ApplicationController
 
   def index
     @users = User.all
+
   end
 
   def edit
@@ -36,9 +38,18 @@ class Admin::UsersController < ApplicationController
   end
 
   def destroy
-    @user.destroy
-    flash[:info] = 'ユーザを削除しました'
-    redirect_to admin_users_path
+    if  User.where(admin: true).count == 1 && @user.admin?
+      flash[:danger] = '管理者はあなたしかいません'
+      redirect_to admin_users_path
+    elsif User.where(admin: true).count > 1 && current_user.id == @user.id
+      @user.destroy
+      flash[:success] = '削除に成功しました'
+      redirect_to new_session_path
+    else
+      @user.destroy
+      flash[:success] = '削除に成功しました'
+      redirect_to admin_users_path
+    end
   end
 
 private
@@ -49,6 +60,10 @@ private
 
   def set_user
     @user = User.find(params[:id])
+  end
+
+  def require_admin
+    redirect_to root_path unless current_user.admin?
   end
 
 end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -8,27 +8,27 @@
         <%= form_with(model: @user, url: admin_user_path(@user.id), local: true) do |f| %>
           <%= f.label :名前 %>
           <br>
-          <br>
           <%= f.text_field :name %>
           <br>
           <br>
           <%= f.label :email %>
-          <br>
           <br>
           <%= f.email_field :email %>
           <br>
           <br>
           <%= f.label :パスワード %>
           <br>
-          <br>
           <%= f.password_field :password %>
           <br>
           <br>
           <%= f.label :パスワード確認 %>
           <br>
-          <br>
           <%= f.password_field :password_confirmation %>
           <br>
+          <br>
+          <br>
+          <%= f.label :admin, "管理者情報" %>
+          <%= f.select :admin, ['true','false']%>
           <br>
           <br>
           <br>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -10,6 +10,7 @@
             <th>名前</th>
             <th>メールアドレス</th>
             <th>タスク数</th>
+            <th>管理権限</th>
             <th>詳細</th>
             <th>編集</th>
             <th>削除</th>
@@ -19,6 +20,7 @@
               <td><%= user.name %></td>
               <td><%= user.email %></td>
               <td><%= user.tasks.count %></td>
+              <td><%= user.admin %></td>
               <td><%= link_to '詳細',admin_user_path(user.id) %></td>
               <td><%= link_to '編集',edit_admin_user_path(user.id) %></td>
               <td><%= link_to '削除',admin_user_path(user.id), method: :delete %></td>
@@ -28,5 +30,3 @@
        </div>
   </div>
 </div>
-
-

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -8,28 +8,27 @@
         <%= form_with(model: @user, url: admin_users_path , local: true) do |f| %>
           <%= f.label :名前 %>
           <br>
-          <br>
           <%= f.text_field :name %>
-          <br> 
-
+          <br>
           <br>
           <%= f.label :email %>
-          <br>
           <br>
           <%= f.email_field :email %>
           <br>
           <br>
           <%= f.label :パスワード %>
           <br>
-          <br>
           <%= f.password_field :password %>
           <br>
           <br>
           <%= f.label :パスワード確認 %>
           <br>
-          <br>
           <%= f.password_field :password_confirmation %>
           <br>
+          <br>
+          <br>
+          <%= f.label :admin, "管理者情報" %>
+          <%= f.select :admin, ['true','false'] %>
           <br>
           <br>
           <br>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -14,10 +14,12 @@
 				<% if logged_in? %>
 					<li><%= link_to 'ログアウト',session_path(current_user.id),method: :delete,class:'btn btn-default btn-block' %></li>
 					<li><%= link_to 'マイページ',user_path(current_user.id),class:'btn btn-default btn-block' %></li>
-					<li><%= link_to 'ユーザ管理',admin_users_path,class:'btn btn-default btn-block' %></li>
-					<li><%= link_to 'ユーザ作成',new_admin_user_path,class:'btn btn-default btn-block' %></li>
 					<li><%= link_to 'タスク一覧',tasks_path,class:'btn btn-default btn-block'  %></li>
 					<li><%= link_to 'タスク作成',new_task_path,class:'btn btn-default btn-block'  %></li>
+				    <% if current_user.admin? %>
+					  <li><%= link_to 'ユーザ管理',admin_users_path,class:'btn btn-default btn-block' %></li>
+					  <li><%= link_to 'ユーザ作成',new_admin_user_path,class:'btn btn-default btn-block' %></li>
+					<% end %>
 				<% else %>
 					<li><%= link_to 'サインアップ',new_user_path,class:'btn btn-default btn-block'%></li>
 					<li><%= link_to 'ログイン',new_session_path,class:'btn btn-default btn-block' %></li>


### PR DESCRIPTION
ユーザに管理ユーザと一般ユーザを区別する

管理ユーザだけがユーザ管理画面にアクセスできるようにする

一般ユーザが管理画面にアクセスした場合、専用の例外（エラー）を出す

ユーザ管理画面でロールの付与と削除ができるようにする

管理ユーザが1人もいなくならないように削除の制御する